### PR TITLE
Fixed uninitialized variable 'files'

### DIFF
--- a/TableauDesktopPy/TableauDesktopPy.py
+++ b/TableauDesktopPy/TableauDesktopPy.py
@@ -412,9 +412,8 @@ class Workbook:
         #template_file = pkg_resources.resource_filename(
         #    "TableauDesktopPy", "assets/README-twb.txt"
         #)
-        template_file = "C:\Users\Medewerker\Documents\GitHub\TableauDesktopPy\TableauDesktopPy\assets\README-twb.txt"
 
-        with open(template_file, "r") as readme_template:
+        with open(r"C:\Users\Medewerker\Documents\GitHub\TableauDesktopPy\TableauDesktopPy\assets\README-twb.txt", "r") as readme_template:
             text = readme_template.read()
 
         # items to fill (in order):

--- a/TableauDesktopPy/TableauDesktopPy.py
+++ b/TableauDesktopPy/TableauDesktopPy.py
@@ -409,9 +409,9 @@ class Workbook:
         message about the README is created.
         """
 
-        template_file = pkg_resources.resource_filename(
-            "TableauDesktopPy", "assets/README-twb.txt"
-        )
+        #template_file = pkg_resources.resource_filename(
+        #    "TableauDesktopPy", "assets/README-twb.txt"
+        #)
         template_file = "C:\Users\Medewerker\Documents\GitHub\TableauDesktopPy\TableauDesktopPy\assets\README-twb.txt"
 
         with open(template_file, "r") as readme_template:

--- a/TableauDesktopPy/TableauDesktopPy.py
+++ b/TableauDesktopPy/TableauDesktopPy.py
@@ -409,11 +409,11 @@ class Workbook:
         message about the README is created.
         """
 
-        #template_file = pkg_resources.resource_filename(
-        #    "TableauDesktopPy", "assets/README-twb.txt"
-        #)
+        template_file = pkg_resources.resource_filename(
+            "TableauDesktopPy", "assets/README-twb.txt"
+        )
 
-        with open(r"C:\Users\Medewerker\Documents\GitHub\TableauDesktopPy\TableauDesktopPy\assets\README-twb.txt", "r") as readme_template:
+        with open(template_file, "r") as readme_template:
             text = readme_template.read()
 
         # items to fill (in order):

--- a/TableauDesktopPy/TableauDesktopPy.py
+++ b/TableauDesktopPy/TableauDesktopPy.py
@@ -438,7 +438,7 @@ class Workbook:
         else:
             dbs = "\n   - ".join(clean_dbs)
 
-        if files == []:
+        if self.files == []:
             files = "\n   - N/A"
         else:
             files = "\n   - ".join(self.files)

--- a/TableauDesktopPy/TableauDesktopPy.py
+++ b/TableauDesktopPy/TableauDesktopPy.py
@@ -412,6 +412,7 @@ class Workbook:
         template_file = pkg_resources.resource_filename(
             "TableauDesktopPy", "assets/README-twb.txt"
         )
+        template_file = "C:\Users\Medewerker\Documents\GitHub\TableauDesktopPy\TableauDesktopPy\assets\README-twb.txt"
 
         with open(template_file, "r") as readme_template:
             text = readme_template.read()


### PR DESCRIPTION
When trying to use the generate_readme method it crashed because the variable `files` was used before it has been initialized. This is at line [441](https://github.com/bleutzinn/TableauDesktopPy/blob/087d71afc2659836d605d3e9bd2459f95776171b/TableauDesktopPy/TableauDesktopPy.py#L441) of `TableauDesktopPy.py`. I changed it to ```if self.files == []:```

Thanks for sharing this module.